### PR TITLE
Update to support PHPStan 0.9

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -24,10 +24,10 @@
         "squizlabs/php_codesniffer": "*"
     },
     "suggest": {
-        "phpstan/phpstan-shim": "~0.8.0"
+        "phpstan/phpstan-shim": "~0.9.0"
     },
     "autoload": {
-        "psr-4": { 
+        "psr-4": {
             "SilbinaryWolf\\SilverstripePHPStan\\": [
                 "src/",
                 "src/type",

--- a/src/DBFieldStaticReturnTypeExtension.php
+++ b/src/DBFieldStaticReturnTypeExtension.php
@@ -2,11 +2,11 @@
 
 namespace SilbinaryWolf\SilverstripePHPStan;
 
-use PHPStanVendor\PhpParser\Node\Expr\StaticCall;
-use PHPStanVendor\PhpParser\Node\Expr\PropertyFetch;
-use PHPStanVendor\PhpParser\Node\Expr\Variable;
-use PHPStanVendor\PhpParser\Node\Expr\Expr;
-use PHPStanVendor\PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Expr\Expr;
+use PhpParser\Node\Scalar\String_;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -19,7 +19,7 @@ use DBField;
 
 class DBFieldStaticReturnTypeExtension implements \PHPStan\Type\DynamicStaticMethodReturnTypeExtension
 {
-    public static function getClass(): string
+    public function getClass(): string
     {
         return DBField::class;
     }

--- a/src/DataListReturnTypeExtension.php
+++ b/src/DataListReturnTypeExtension.php
@@ -2,10 +2,10 @@
 
 namespace SilbinaryWolf\SilverstripePHPStan;
 
-use PHPStanVendor\PhpParser\Node\Expr\MethodCall;
-use PHPStanVendor\PhpParser\Node\Expr\PropertyFetch;
-use PHPStanVendor\PhpParser\Node\Expr\Variable;
-use PHPStanVendor\PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -20,7 +20,7 @@ use DataList;
 
 class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTypeExtension
 {
-    public static function getClass(): string
+    public function getClass(): string
     {
         return DataList::class;
     }
@@ -90,7 +90,7 @@ class DataListReturnTypeExtension implements \PHPStan\Type\DynamicMethodReturnTy
         if (!$type || !($type instanceof DataListType)) {
             return $methodReflection->getReturnType();
         }
-        
+
         switch ($name) {
             // DataList
             case 'filter':

--- a/src/DataObjectGetStaticReturnTypeExtension.php
+++ b/src/DataObjectGetStaticReturnTypeExtension.php
@@ -2,10 +2,10 @@
 
 namespace SilbinaryWolf\SilverstripePHPStan;
 
-use PHPStanVendor\PhpParser\Node\Expr\StaticCall;
-use PHPStanVendor\PhpParser\Node\Expr\PropertyFetch;
-use PHPStanVendor\PhpParser\Node\Expr\Variable;
-use PHPStanVendor\PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\StaticCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -19,7 +19,7 @@ use DataObject;
 
 class DataObjectGetStaticReturnTypeExtension implements \PHPStan\Type\DynamicStaticMethodReturnTypeExtension
 {
-    public static function getClass(): string
+    public function getClass(): string
     {
         return DataObject::class;
     }
@@ -68,7 +68,7 @@ class DataObjectGetStaticReturnTypeExtension implements \PHPStan\Type\DynamicSta
                 /*if ($arg instanceof PropertyFetch) {
                     $vars = $scope->getVariableTypes();
                    var_dump($vars);
-                    var_dump($arg);  
+                    var_dump($arg);
                 }*/
                 return $methodReflection->getReturnType();
             break;

--- a/src/DataObjectReturnTypeExtension.php
+++ b/src/DataObjectReturnTypeExtension.php
@@ -3,13 +3,12 @@
 namespace SilbinaryWolf\SilverstripePHPStan;
 
 use PHPStan\Type\DynamicMethodReturnTypeExtension;
-use PHPStan\Reflection\BrokerAwareClassReflectionExtension;
 use PHPStan\Broker\Broker;
 
-use PHPStanVendor\PhpParser\Node\Expr\MethodCall;
-use PHPStanVendor\PhpParser\Node\Expr\PropertyFetch;
-use PHPStanVendor\PhpParser\Node\Expr\Variable;
-use PHPStanVendor\PhpParser\Node\Scalar\String_;
+use PhpParser\Node\Expr\MethodCall;
+use PhpParser\Node\Expr\PropertyFetch;
+use PhpParser\Node\Expr\Variable;
+use PhpParser\Node\Scalar\String_;
 
 use PHPStan\Reflection\ClassReflection;
 use PHPStan\Reflection\MethodReflection;
@@ -29,7 +28,7 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
     /** @var Broker */
     private $broker;
 
-    public static function getClass(): string
+    public function getClass(): string
     {
         return DataObject::class;
     }
@@ -58,7 +57,9 @@ class DataObjectReturnTypeExtension implements DynamicMethodReturnTypeExtension
             return $methodReflection->getReturnType();
         }
         if ($type instanceof StaticType) {
-            $className = $type->getClass();
+            if (count($type->getReferencedClasses()) === 1) {
+                $className = $type->getReferencedClasses()[0];
+            }
         } else {
             return $methodReflection->getReturnType();
         }

--- a/src/MethodClassReflectionExtension.php
+++ b/src/MethodClassReflectionExtension.php
@@ -6,7 +6,7 @@ use \ReflectionClass;
 use \ReflectionMethod;
 
 use PHPStan\Reflection\MethodsClassReflectionExtension;
-use PHPStan\Reflection\BrokerAwareClassReflectionExtension;
+use PHPStan\Reflection\BrokerAwareExtension;
 use PHPStan\Broker\Broker;
 
 use PHPStan\Reflection\ClassReflection;
@@ -14,6 +14,7 @@ use PHPStan\Reflection\MethodReflection;
 use PHPStan\Type\FileTypeMapper;
 use PHPStan\Type\ObjectType;
 use PHPStan\Reflection\Php\PhpMethodReflection;
+use PHPStan\Analyser\Scope;
 
 // Silverstripe
 use Object;
@@ -21,7 +22,7 @@ use Config;
 use DataObject;
 use ContentController;
 
-class MethodClassReflectionExtension implements MethodsClassReflectionExtension, BrokerAwareClassReflectionExtension
+class MethodClassReflectionExtension implements MethodsClassReflectionExtension, BrokerAwareExtension
 {
     /** @var MethodReflection[][] */
     private $methods = [];
@@ -77,7 +78,7 @@ class MethodClassReflectionExtension implements MethodsClassReflectionExtension,
                 $extensionClassReflection = $this->broker->getClass($extensionClass);
                 foreach (get_class_methods($extensionClass) as $methodName) {
                     /** @var $methodReflection PhpMethodReflection */
-                    $methodReflection = $extensionClassReflection->getMethod($methodName);
+                    $methodReflection = $extensionClassReflection->getNativeMethod($methodName);
                     $methods[strtolower($methodName)] = $methodReflection;
                 }
             }
@@ -91,7 +92,7 @@ class MethodClassReflectionExtension implements MethodsClassReflectionExtension,
         foreach (get_class_methods($class) as $methodName) {
             if ($methodName && $methodName[0] === '_' && isset($methodName[1]) && $methodName[1] !== '_') {
                 $uncachedMethodName = substr($methodName, 1);
-                $methods[strtolower($uncachedMethodName)] = new CachedMethod($classReflection->getMethod($methodName));
+                $methods[strtolower($uncachedMethodName)] = new CachedMethod($classReflection->getNativeMethod($methodName));
             }
         }
 
@@ -106,7 +107,7 @@ class MethodClassReflectionExtension implements MethodsClassReflectionExtension,
             $failoverClassReflection = $this->broker->getClass($class);
             foreach (get_class_methods($class) as $methodName) {
                 /** @var $methodReflection PhpMethodReflection */
-                $methodReflection = $failoverClassReflection->getMethod($methodName);
+                $methodReflection = $failoverClassReflection->getNativeMethod($methodName);
                 $methods[strtolower($methodName)] = $methodReflection;
             }
         }

--- a/src/type/DataListType.php
+++ b/src/type/DataListType.php
@@ -25,7 +25,9 @@ class DataListType extends ObjectType implements StaticResolvableType
 
     public function describe(): string
     {
-        return sprintf('%s<%s[]>', $this->dataListType->getClass(), $this->itemType->getClass());
+        $dataListTypeClass = count($this->dataListType->getReferencedClasses()) === 1 ? $this->dataListType->getReferencedClasses()[0] : '';
+        $itemTypeClass = count($this->itemType->getReferencedClasses()) === 1 ? $this->itemType->getReferencedClasses()[0] : '';
+        return sprintf('%s<%s[]>', $dataListTypeClass, $itemTypeClass);
     }
 
     public function getDataListType(): ObjectType
@@ -38,9 +40,9 @@ class DataListType extends ObjectType implements StaticResolvableType
         return $this->itemType;
     }
 
-    public function getClass(): string
+    public function getReferencedClasses(): array
     {
-        return $this->dataListType->getClass();
+        return $this->dataListType->getReferencedClasses();
     }
 
     public function resolveStatic(string $className): Type


### PR DESCRIPTION
[Version 0.9 of PHPStan](https://github.com/phpstan/phpstan/releases/tag/0.9) included a number of BC breaks. These changes update it to get in line with the latest major version, `0.9`.